### PR TITLE
use | instead of , as commas can be using in sentences

### DIFF
--- a/web/concrete/attributes/select/controller.php
+++ b/web/concrete/attributes/select/controller.php
@@ -312,7 +312,7 @@ class Controller extends AttributeTypeController
                         // list of SelectAttributeOption:ID items and new items.
                         $options = array();
                         if ($data['atSelectOptionValue']) {
-                            foreach (explode(',', $data['atSelectOptionValue']) as $value) {
+                            foreach (explode('|', $data['atSelectOptionValue']) as $value) {
                                 if (preg_match('/SelectAttributeOption\:(.+)/i', $value, $matches)) {
                                     $option = Option::getByID($matches[1]);
                                 } else {
@@ -525,7 +525,7 @@ class Controller extends AttributeTypeController
     {
         $r = \Request::getInstance();
         $value = $r->query->get('value');
-        $values = explode(',', $value);
+        $values = explode('|', $value);
         $response = array();
         foreach ($values as $value) {
             $value = trim($value);

--- a/web/concrete/attributes/select/form.php
+++ b/web/concrete/attributes/select/form.php
@@ -49,7 +49,7 @@ if ($akSelectAllowOtherValues) {
 		foreach($selectedOptions as $optionID) {
 			$values[] = 'SelectAttributeOption:' . $optionID;
 		}
-		$value = implode(',', $values);
+		$value = implode('|', $values);
 	}
 
 
@@ -83,7 +83,8 @@ if ($akSelectAllowOtherValues) {
 					}
 				},
 				<? if ($akSelectAllowMultipleValues) { ?>
-					tokenSeparators: [','],
+					tokenSeparators: ['|'],
+					separator: "|",
 					multiple: true,
 				<? } else { ?>
 					maximumSelectionSize: 1,


### PR DESCRIPTION
I have recently had a client that wish to add to a select list where in some circumstances they wished to use commas. This is using **Select Attribute that a user can add too and select multiple**

I have currently overriden this by extending the select controller and form.php to use pipes which seems to be common practice in linux.

This pull request is just a requested enhancement
